### PR TITLE
Fix chunk text access for prompt submission

### DIFF
--- a/src/lib/openai.ts
+++ b/src/lib/openai.ts
@@ -58,13 +58,13 @@ export class OpenAIClient {
       // we need to split it up - in the future lets do this more intelligently
     }
     let fullSource = "";
-    for (const textChunk of chunked) {
+    for (const chunk of chunked) {
       const subPrompt =
         chunked.length === 1
           ? "The following is the contents of the file:"
           : "The following is a partial file, with the start or end omitted. Ignore any syntax errors, and convert the code exactly as is:";
       const prompt = `${initialPrompt}
-    ${subPrompt}\n\n${textChunk}`;
+    ${subPrompt}\n\n${chunk.text}`;
       const completion = await this.runCompletion(prompt);
       fullSource += completion;
     }


### PR DESCRIPTION
Chunk as returned by the GPT4Tokenizer is an Object with a text attribute and a byte-pair encoding attribute, but the whole object was being passed into the prompt rather than just the text attribute.